### PR TITLE
Removed root opencode.json

### DIFF
--- a/opencode.json
+++ b/opencode.json
@@ -1,5 +1,0 @@
-{
-  "env": {
-    "PATH": "/Users/qbix/.local/share/fnm/node-versions/v24.18.0/installation/bin:/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin"
-  }
-}

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "Sportex",
-  "version": "1.37.0",
+  "version": "1.37.2",
   "private": true,
   "scripts": {
     "dev": "next dev --port=3000",


### PR DESCRIPTION
- Deleted opencode.json from the project root to avoid cluttering the
  workspace with tool-specific config
- Consolidated opencode configuration inside .opencode/opencode.json
- Installed Node.js via Homebrew so the agent can run vitest, npm, and
  other Node tools directly without relying on fnm PATH injection
